### PR TITLE
loosen author only restriction on seeing ihub entries in maret

### DIFF
--- a/maret/views.py
+++ b/maret/views.py
@@ -792,7 +792,7 @@ class OrganizationDetailView(UserRequiredMixin, CommonDetailView):
         org = self.get_object()
 
         entries_dict = dict()
-        if in_ihub_edit_group(self.request.user):
+        if bool(hasattr(self.request.user, "ihub_user")) and self.request.user.ihub_user:
             if org.entries.exists():
                 entries = org.entries.all()
                 statuses = Status.objects.filter(entries__in=entries).distinct()


### PR DESCRIPTION
they used to be author only, should have been open to all users.