### PR TITLE
add local test database so keepdb works properly

### DIFF
--- a/dm_apps/default_conf.py
+++ b/dm_apps/default_conf.py
@@ -103,6 +103,9 @@ if USE_LOCAL_DB:
     my_default_db = {
         'ENGINE': 'django.contrib.gis.db.backends.spatialite' if GEODJANGO else 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'TEST': {
+            'NAME': os.path.join(BASE_DIR, 'test.sqlite3'),
+        }
     }
     DB_MODE = "LOCAL"
     DB_NAME = "db.sqlite3"


### PR DESCRIPTION
Update the default_conf.py to create a persistent test database for local deployments.  This allows the keepdb option to act as expected and removes the need to rerun migrations each time you run unit tests.  